### PR TITLE
Feature/consumer

### DIFF
--- a/consumer_service/Dockerfile
+++ b/consumer_service/Dockerfile
@@ -1,0 +1,17 @@
+# use Python base image
+FROM python:3.11-slim
+
+# set working directory
+WORKDIR /app
+
+# copy dependency files
+COPY requirements.txt /app/requirements.txt
+
+# install the dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# and copy producer service code
+COPY . /app
+
+# default command
+CMD ["python", "main.py"]

--- a/consumer_service/config.py
+++ b/consumer_service/config.py
@@ -1,0 +1,14 @@
+import os
+
+# the kafka configuration
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "podcast-files")
+
+# elasticsearch configuration
+ES_HOST = os.getenv("ES_HOST", "http://elasticsearch:9200")
+ES_INDEX = os.getenv("ES_INDEX", "podcasts_metadata")
+
+# mongoDB configuration
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://mongo:27017/")
+MONGO_DB = os.getenv("MONGO_DB", "podcasts_db")
+MONGO_COLLECTION = os.getenv("MONGO_COLLECTION", "podcasts_files")

--- a/consumer_service/constants.py
+++ b/consumer_service/constants.py
@@ -1,0 +1,6 @@
+# the elasticsearch constants
+ES_DEFAULT_INDEX = "podcasts_metadata"
+
+# mongoDB constants
+MONGO_DEFAULT_DB = "podcasts_db"
+MONGO_DEFAULT_COLLECTION = "podcasts_files"

--- a/consumer_service/elastic_writer.py
+++ b/consumer_service/elastic_writer.py
@@ -9,7 +9,8 @@ def write_metadata_to_es(unique_id: str, metadata: dict):
 
     doc = {
         "id": unique_id,
-        **metadata
+        **metadata,
+        "ingested_at": datetime.utcnow().isoformat()
     }
 
     es.index(index=ES_INDEX, id=unique_id, document=doc)

--- a/consumer_service/elastic_writer.py
+++ b/consumer_service/elastic_writer.py
@@ -5,4 +5,12 @@ def write_metadata_to_es(unique_id: str, metadata: dict):
     """
     and write the metadata to elasticsearch  with unique id
     """
-    ...
+    es = Elasticsearch(ES_HOST)
+
+    doc = {
+        "id": unique_id,
+        **metadata
+    }
+
+    es.index(index=ES_INDEX, id=unique_id, document=doc)
+    print(f"[Elasticsearch] Indexed document with ID: {unique_id}")

--- a/consumer_service/elastic_writer.py
+++ b/consumer_service/elastic_writer.py
@@ -1,0 +1,8 @@
+from elasticsearch import Elasticsearch
+from config import ES_HOST, ES_INDEX
+
+def write_metadata_to_es(unique_id: str, metadata: dict):
+    """
+    and write the metadata to elasticsearch  with unique id
+    """
+    ...

--- a/consumer_service/id_generator.py
+++ b/consumer_service/id_generator.py
@@ -1,0 +1,9 @@
+import hashlib
+import json
+
+def generate_unique_id(data: dict) -> str:
+    """
+    first generate a unique id from the json data using sha256 hash
+    """
+    json_str = json.dumps(data, sort_keys=True)
+    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/consumer_service/kafka_consumer.py
+++ b/consumer_service/kafka_consumer.py
@@ -7,5 +7,12 @@ def consume_messages():
     finally consume messages from kafka topic and yield json objects
     so that other modules can process them
     """
-    ...
-
+    consumer = KafkaConsumer(
+        KAFKA_TOPIC,
+        bootstrap_servers=[KAFKA_BROKER],
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        auto_offset_reset="earliest",
+        group_id="podcast-consumer-group"
+    )
+    for message in consumer:
+        yield message.value

--- a/consumer_service/kafka_consumer.py
+++ b/consumer_service/kafka_consumer.py
@@ -1,0 +1,11 @@
+from kafka import KafkaConsumer
+import json
+from config import KAFKA_BROKER, KAFKA_TOPIC
+
+def consume_messages():
+    """
+    finally consume messages from kafka topic and yield json objects
+    so that other modules can process them
+    """
+    ...
+

--- a/consumer_service/main.py
+++ b/consumer_service/main.py
@@ -7,11 +7,19 @@ def main():
     """
     entry point for producer Service
     """
-    # start generate unique id
+    print("[Consumer] Starting consumer service..")
+    for json_data in consume_messages():
+        print(f"[Consumer] Received message: {json_data}")
 
-    # and write metadata to elasticsearch
+        # start generate unique id
+        unique_id = generate_unique_id(json_data)
+        print(f"[Consumer] Generated unique_id: {unique_id}")
 
-    # lastly save actual file into mongodb
+        # and write metadata to elasticsearch
+        write_metadata_to_es(unique_id, json_data)
+
+        # lastly save actual file into mongodb
+        save_file_to_mongo(unique_id, json_data["path"])
     
 if __name__ == "__main__":
     main()

--- a/consumer_service/main.py
+++ b/consumer_service/main.py
@@ -1,0 +1,17 @@
+from kafka_consumer import consume_messages
+from id_generator import generate_unique_id
+from elastic_writer import write_metadata_to_es
+from mongo_writer import save_file_to_mongo
+
+def main():
+    """
+    entry point for producer Service
+    """
+    # start generate unique id
+
+    # and write metadata to elasticsearch
+
+    # lastly save actual file into mongodb
+    
+if __name__ == "__main__":
+    main()

--- a/consumer_service/mongo_writer.py
+++ b/consumer_service/mongo_writer.py
@@ -7,7 +7,11 @@ def save_file_to_mongo(unique_id: str, file_path: str):
     """
     here save the actual .wav file into mongoDB using GridFS
     """
-    
-    client = ...
-    db = ...
-    fs = ...
+    client = pymongo.MongoClient(MONGO_URI)
+    db = client[MONGO_DB]
+    fs = gridfs.GridFS(db, collection=MONGO_COLLECTION)
+
+    path = pathlib.Path(file_path)
+    with open(path, "rb") as f:
+        file_id = fs.put(f, filename=path.name, unique_id=unique_id)
+        print(f"[MongoDB] Stored file {path.name} with unique_id={unique_id}, file_id={file_id}")

--- a/consumer_service/mongo_writer.py
+++ b/consumer_service/mongo_writer.py
@@ -1,0 +1,13 @@
+import pymongo
+import pathlib
+import gridfs
+from config import MONGO_URI, MONGO_DB, MONGO_COLLECTION
+
+def save_file_to_mongo(unique_id: str, file_path: str):
+    """
+    here save the actual .wav file into mongoDB using GridFS
+    """
+    
+    client = ...
+    db = ...
+    fs = ...

--- a/consumer_service/requirements.txt
+++ b/consumer_service/requirements.txt
@@ -1,0 +1,3 @@
+kafka-python==2.0.2
+pymongo==4.8.0
+elasticsearch==8.15.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,3 +31,48 @@ services:
       PODCASTS_DIR: /host_podcasts
     volumes:
       - /Users/elifisher/Downloads/podcasts:/host_podcasts:ro
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.15.2
+    depends_on:
+      - elasticsearch
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+
+  mongo:
+    image: mongo:7.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  consumer:
+    build: ./consumer_service
+    depends_on:
+      - kafka
+      - elasticsearch
+      - mongo
+    environment:
+      KAFKA_BROKER: kafka:9092
+      KAFKA_TOPIC: podcast-files
+      ES_HOST: http://elasticsearch:9200
+      ES_INDEX: podcasts_metadata
+      MONGO_URI: mongodb://mongo:27017/
+      MONGO_DB: podcasts_db
+      MONGO_COLLECTION: podcasts_files
+    volumes:
+      - /Users/elifisher/Downloads/podcasts:/host_podcasts:ro
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
In this (second) step, I created,
The consumer listens to Kafka through the topic I created (podcast-files), where it is found for each new message that comes in. The views are json files with basic information about the file..

When a message arrives, a consumer reads it.

So that each file is clearly identified without repetitions, we created as requested a unique_id that is calculated by the hash of the message content..

The consumer takes all the metadata and the unique_id, and I also added ingested_at (the date the document was ingested).. and sends this to the Elasticsearch database into the podcasts_metadata index.

The consumer also opens the original path on the computer and uploads the binary content to Mongo by GridFS, GridFS stores the file in two parts:
In the metadata document (.files file).
In the content pieces (.chunks file).
The file name is linked to the unique_id, so that there is a match for Elasticsearch...

The result is two things, both Elasticsearch with metadata (say for analysis and search)
and also Mongo where the file is in the source itself.
And there is also Kibana to see the Elasticsearch.