### PR TITLE
Feature/query api

### DIFF
--- a/analyzer_service/config.py
+++ b/analyzer_service/config.py
@@ -2,8 +2,7 @@ import os
 
 # kafka config
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
-KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "transcribed-files")
-
+KAFKA_TOPIC = os.getenv("ANALYZER_TOPIC", "transcribed-files")
 # elastic config
 ES_HOST = os.getenv("ES_HOST", "http://elasticsearch:9200")
 ES_INDEX = os.getenv("ES_INDEX", "podcasts_metadata_v2")

--- a/consumer_service/config.py
+++ b/consumer_service/config.py
@@ -2,7 +2,7 @@ import os
 
 # the kafka configuration
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
-KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "podcast-files")
+KAFKA_TOPIC = os.getenv("CONSUMER_TOPIC", "podcast-files")
 
 # elasticsearch configuration
 ES_HOST = os.getenv("ES_HOST", "http://elasticsearch:9200")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     restart: on-failure
     environment:
       KAFKA_BROKER: kafka:${KAFKA_INTERNAL_PORT}
-      KAFKA_TOPIC: ${KAFKA_TOPIC}
+      PRODUCER_TOPIC: ${PRODUCER_TOPIC}
       PODCASTS_DIR: ${PODCASTS_DIR}
     volumes:
       - ${PODCASTS_DIR_HOST}:${PODCASTS_DIR}:ro
@@ -58,7 +58,7 @@ services:
     restart: on-failure
     environment:
       KAFKA_BROKER: kafka:${KAFKA_INTERNAL_PORT}
-      KAFKA_TOPIC: ${KAFKA_TOPIC}
+      CONSUMER_TOPIC: ${CONSUMER_TOPIC}
       ES_HOST: ${ES_HOST}:${ES_PORT}
       ES_INDEX: ${ES_INDEX}
       MONGO_URI: ${MONGO_URI}
@@ -79,7 +79,7 @@ services:
     restart: on-failure
     environment:
       KAFKA_BROKER: kafka:${KAFKA_INTERNAL_PORT}
-      KAFKA_TOPIC: ${KAFKA_TOPIC}
+      TRANSCRIBER_TOPIC: ${TRANSCRIBER_TOPIC}
       ES_HOST: ${ES_HOST}:${ES_PORT}
       ES_INDEX: ${ES_INDEX}
     volumes:
@@ -97,7 +97,7 @@ services:
     restart: on-failure
     environment:
       KAFKA_BROKER: kafka:${KAFKA_INTERNAL_PORT}
-      KAFKA_TOPIC: ${ANALYZER_TOPIC}
+      ANALYZER_TOPIC: ${ANALYZER_TOPIC}
       ES_HOST: ${ES_HOST}:${ES_PORT}
       ES_INDEX: ${ES_INDEX}
       HOSTILE_WORDLIST_BASE64: ${HOSTILE_WORDLIST_BASE64}
@@ -105,6 +105,21 @@ services:
       BDS_THRESHOLD: ${BDS_THRESHOLD}
       MEDIUM_THRESHOLD: ${MEDIUM_THRESHOLD}
       HIGH_THRESHOLD: ${HIGH_THRESHOLD}
+
+  query_service:
+    build:
+      context: .
+      dockerfile: ./query_service/Dockerfile
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    restart: on-failure
+    environment:
+      ES_HOST: ${ES_HOST}:${ES_PORT}
+      ES_INDEX: ${ES_INDEX}
+    ports:
+      - "${QUERY_PORT}:${QUERY_PORT}"
+
       
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2

--- a/producer_service/Dockerfile
+++ b/producer_service/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # copy dependency files
-COPY query_service/requirements.txt /app/requirements.txt
+COPY producer_service/requirements.txt /app/requirements.txt
 
 # install the dependencies
 RUN pip install --no-cache-dir -r requirements.txt
@@ -13,8 +13,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # copy common utilities
 COPY common /app/common
 
-# and copy query service code
-COPY query_service /app
+# and copy producer service code
+COPY producer_service /app
 
-# default command (run uvicorn server to fastapi app)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# default command
+CMD ["python", "main.py"]

--- a/producer_service/config.py
+++ b/producer_service/config.py
@@ -5,4 +5,4 @@ PODCASTS_DIR = os.getenv("PODCASTS_DIR", "/Users/elifisher/Downloads/podcasts")
 
 # and kafka configuration
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
-KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "podcast-files")
+KAFKA_TOPIC = os.getenv("PRODUCER_TOPIC", "podcast-files")

--- a/query_service/Dockerfile
+++ b/query_service/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # copy dependency files
 COPY query_service/requirements.txt /app/requirements.txt
 
-# install the dependencies
+# need install the dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
 # copy common utilities
@@ -16,5 +16,5 @@ COPY common /app/common
 # and copy query service code
 COPY query_service /app
 
-# default command (run uvicorn server to fastapi app)
+# default command
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/query_service/config.py
+++ b/query_service/config.py
@@ -1,0 +1,5 @@
+import os
+
+# es config
+ES_HOST = os.getenv("ES_HOST", "http://elasticsearch:9200")
+ES_INDEX = os.getenv("ES_INDEX", "podcasts_metadata_v2")

--- a/query_service/main.py
+++ b/query_service/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, Query
+from query_engine import get_by_id, get_by_threat, search_by_keyword, get_stats
+
+app = FastAPI(title="Podcast Query Service", version="1.0.0")
+
+@app.get("/query/by_id/{unique_id}")
+def query_by_id(unique_id: str):
+    return get_by_id(unique_id)
+
+@app.get("/query/by_threat/{level}")
+def query_by_threat(level: str):
+    return get_by_threat(level)
+
+@app.get("/query/search")
+def query_search(keyword: str = Query(..., description="keyword to saerch in transcription")):
+    return search_by_keyword(keyword)
+
+@app.get("/query/stats")
+def query_stats():
+    return get_stats()

--- a/query_service/main.py
+++ b/query_service/main.py
@@ -3,18 +3,22 @@ from query_engine import get_by_id, get_by_threat, search_by_keyword, get_stats
 
 app = FastAPI(title="Podcast Query Service", version="1.0.0")
 
+# endpoint to get document by unique_id
 @app.get("/query/by_id/{unique_id}")
 def query_by_id(unique_id: str):
     return get_by_id(unique_id)
 
+# endpoint to get documents by threat level
 @app.get("/query/by_threat/{level}")
 def query_by_threat(level: str):
     return get_by_threat(level)
 
+# endpoint to search documents by keyword in transcription
 @app.get("/query/search")
 def query_search(keyword: str = Query(..., description="keyword to saerch in transcription")):
     return search_by_keyword(keyword)
 
+# and endpoint to get stats
 @app.get("/query/stats")
 def query_stats():
     return get_stats()

--- a/query_service/query_engine.py
+++ b/query_service/query_engine.py
@@ -6,14 +6,60 @@ logger = Logger.get_logger()
 
 es = Elasticsearch(ES_HOST)
 
+# simple get by id function
 def get_by_id(unique_id: str) -> dict:
-    ...
+    try:
+        doc = es.get(index=ES_INDEX, id=unique_id)
+        return doc["_source"]
+    except Exception as e:
+        logger.error(f"Failed to fetch doc by id={unique_id}: {e}")
+        raise
 
+# get all documents with a specific threat level (like"low", "medium", "high" (l.f))
 def get_by_threat(level: str) -> list[dict]:
-    ...
+    try:
+        resp = es.search(
+            index=ES_INDEX,
+            query={"match": {"bds_threat_level": level}}
+        )
+        return [hit["_source"] for hit in resp["hits"]["hits"]]
+    except Exception as e:
+        logger.error(f"Failed to fetch docs by threat level={level}: {e}")
+        raise
 
+
+# here i cen search documents by keyword in transcription field
 def search_by_keyword(keyword: str) -> list[dict]:
-    ...
+    try:
+        resp = es.search(
+            index=ES_INDEX,
+            query={"match": {"transcription": keyword}}
+        )
+        return [hit["_source"] for hit in resp["hits"]["hits"]]
+    except Exception as e:
+        logger.error(f"Failed to search docs by keyword={keyword}: {e}")
+        raise
 
+
+# get some basic stats like counts of bds vs non-bds and threat levels (i use aggregations (means summary the data)l.f)
 def get_stats() -> dict:
-    ...
+    try:
+        # aggregation query to get counts of is_bds and threat levels
+        resp = es.search(
+            index=ES_INDEX,
+            size=0,
+            aggs={
+                "is_bds_counts": {"terms": {"field": "is_bds"}},
+                "threat_levels": {"terms": {"field": "bds_threat_level"}}
+            }
+        )
+        # and return the aggregation results as a dictionary
+        stats = {
+            "is_bds": resp["aggregations"]["is_bds_counts"]["buckets"],
+            "threat_levels": resp["aggregations"]["threat_levels"]["buckets"],
+        }
+        return stats
+    
+    except Exception as e:
+        logger.error(f"Failed to fetch stats: {e}")
+        raise

--- a/query_service/query_engine.py
+++ b/query_service/query_engine.py
@@ -1,0 +1,19 @@
+from elasticsearch import Elasticsearch
+from config import ES_HOST, ES_INDEX
+from common.logger import Logger
+
+logger = Logger.get_logger()
+
+es = Elasticsearch(ES_HOST)
+
+def get_by_id(unique_id: str) -> dict:
+    ...
+
+def get_by_threat(level: str) -> list[dict]:
+    ...
+
+def search_by_keyword(keyword: str) -> list[dict]:
+    ...
+
+def get_stats() -> dict:
+    ...

--- a/query_service/query_engine.py
+++ b/query_service/query_engine.py
@@ -53,11 +53,11 @@ def get_stats() -> dict:
                 "threat_levels": {"terms": {"field": "bds_threat_level"}}
             }
         )
-        # and return the aggregation results as a dictionary
+        # and return the aggregation results as a dictionary (and handles even if still empty (key) l.f)
         stats = {
-            "is_bds": resp["aggregations"]["is_bds_counts"]["buckets"],
-            "threat_levels": resp["aggregations"]["threat_levels"]["buckets"],
-        }
+            "is_bds": resp.get("aggregations", {}).get("is_bds_counts", {}).get("buckets", []),
+            "threat_levels": resp.get("aggregations", {}).get("threat_levels", {}).get("buckets", []),
+        }        
         return stats
     
     except Exception as e:

--- a/query_service/requirements.txt
+++ b/query_service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.0
+elasticsearch==8.15.1

--- a/transcriber_service/config.py
+++ b/transcriber_service/config.py
@@ -2,7 +2,7 @@ import os
 
 # a path to local podcasts directory
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
-KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "processed-files")
+KAFKA_TOPIC = os.getenv("TRANSCRIBER_TOPIC", "processed-files")
 
 # elasticsearch configuration
 ES_HOST = os.getenv("ES_HOST", "http://elasticsearch:9200")


### PR DESCRIPTION
I also made a new service here query_service so that it would also be an independent microservice
I used FastAPI which also has structured JSON and that's what I learned...
It will contain clear endpoints, each of which gives a value that I can give to the researcher and that will be useful

The endpoints I made
Test for searching by ID
GET /query/by_id/{unique_id}
Then it returns all the information (this means metadata, transcription, and BDS analysis
The reason in my opinion why this is valuable for the researcher: if he has a specific ID (for example, that he saw from the dashboard in Kibana that we made, then it brings it from there and allows him to get the full picture on that alone.

There is also a search by threat level
GET /query/by_threat/{level}
But it returns a list of documents with bds_threat_level by none/medium/high
The reason why this is valuable for the researcher: because then it allows you to go straight to the most dangerous categories..

And there is also a search by Keywords
GET /query/search?keyword=palestine (for example)

What it does: It searches within the transcription of the documents for the word we requested.
This is of course valuable to the researcher, allowing him to quickly find all the files in which the word he was looking for appeared

There are also general statistics at the end
http
GET /query/stats

Then it will return a count or distribution of documents: how many is_bds=True, and also return me how many high, medium, none
This is of course valuable to the researcher, because then it gives a quick snapshot of the entire material according to data segmentation

Of course, each answer will be in a uniform json format as was in the request
for example
[
{
"id": "abc123",
"file_name": "download.wav",
"created_at": "2025-09-08T12:00:00Z",
"transcription": "....",
"bds_percent": 12.5,
"is_bds": true,
"bds_threat_level": "high"
},
...
]

In short, all these queries together cover both a granular approach, a view, and a flexible search.. so there is a representative range
I also use es as the basis for all searches (all the information is already there metadata , transcription , BDS and it's cool too and it was probably the reason for using es here in the requirements...